### PR TITLE
fix(deps): float the whole @nestjs/* set together (v0.24.2)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "anki-mcp-server",
   "display_name": "Anki MCP Server",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "license": "MIT",
   "description": "Model Context Protocol server for Anki spaced repetition flashcard application",
   "long_description": "Transform your Anki experience with natural language interaction - like having a private tutor. This MCP server enables AI assistants to interact with Anki, allowing them to explain concepts, make learning more engaging, provide context, and adapt to your learning style. Features include review sessions, deck management, note creation and editing, and more.\n\nRequires Anki with the AnkiConnect plugin installed.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ankimcp/anki-mcp-server",
-  "version": "0.24.0",
+  "version": "0.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ankimcp/anki-mcp-server",
-      "version": "0.24.0",
+      "version": "0.24.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/core": "2.0.0",
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/server": "2.0.0",
         "@nestjs/common": "^11.1.29",
         "@nestjs/config": "^4.0.4",
-        "@nestjs/core": "11.1.29",
+        "@nestjs/core": "^11.1.29",
         "@nestjs/microservices": "^11.1.29",
         "@nestjs/platform-express": "^11.1.29",
         "@rekog/mcp-nest": "^2.0.0",
@@ -4388,9 +4388,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.29",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.29.tgz",
-      "integrity": "sha512-zkeNRlfiQIH/044r5zphjNzKYxBRC4O00onTdCsH2qq0R30Ixo0gOS9so5TadEbJJCuGNm0Vx3PBE2FG2vkBdA==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.2.3.tgz",
+      "integrity": "sha512-obdauJXHfthhepbV+LpGe88OeBlR/Kw9lwjLo0Utzc//agoLXYb9DUGhPQWtm81IpBWMv+19eiwcve9MsBZwXA==",
       "license": "MIT",
       "dependencies": {
         "file-type": "21.3.4",
@@ -4434,9 +4434,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.29",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.29.tgz",
-      "integrity": "sha512-ANXnZxirMNAY+JuRHCIYIdTfbhX3rizeSbJloub/4EYwpIfCuUoaz9woOofWmywYYc3gsVkLxVZV03gqntI8vA==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.2.3.tgz",
+      "integrity": "sha512-vkA9/Ja0Z3hvqXErSa+HaxrfF+cNXthNFi8VPNEKVli4rMd009yExAl0gLmko/Kf8peDXr72u1RN+j9Da2ukHg==",
       "license": "MIT",
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
@@ -4473,9 +4473,9 @@
       }
     },
     "node_modules/@nestjs/microservices": {
-      "version": "11.1.29",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.29.tgz",
-      "integrity": "sha512-Z97VBDwgarzj08ZoC5ItJDIkUiDsAXm3kx2lWc0YtpnOCtQxmGe6tM2eI1tlKJWXDIWBi6iNxtOCJU76F+Y/cA==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.2.3.tgz",
+      "integrity": "sha512-HcMm6c8dwKbU0CSOFYxcHZ17YkQawnVzpfT58u24/fAzmsA1WJyfCej5+uONjuG7L/CG76OSxKZlZBNzcxkUiw==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -4531,9 +4531,9 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.29",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.29.tgz",
-      "integrity": "sha512-OngsAjdzM+SbbmP1XojKfBgl0Lj7u8b7IK5duwpFymzNP5EmjS8ujvqck9M8h0L14I91aRIFSjIpVfHj8WVtqw==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.2.3.tgz",
+      "integrity": "sha512-YFQvRXT2de1qNL9LJPUBQ31+RsfI4cJ+sbpU9ENM/hDCgoHSEhm7oxUuGGKmhTZBNZEYm8mDYdfoTFmAH1LIJg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
@@ -4575,9 +4575,9 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "11.1.29",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.29.tgz",
-      "integrity": "sha512-u+aEp90Ly3uQbLoicZs+ZOrJTyvaD0fbd6dpnSgFZz5Bf77gbKKfr+xFE2JxqZuIH15HlBrqDL7/OL2qL8oG+A==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.2.3.tgz",
+      "integrity": "sha512-7ANDWlkm8Xw4CYIhCNZhtBzANsQUKqjteA2yx/6sjqGyWhekeBKz8wgCJykm0vo+ltrg6U34dZlm2NgiRcNHPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ankimcp/anki-mcp-server",
   "mcpName": "ai.ankimcp/anki-mcp-server",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Model Context Protocol server for Anki - enables AI assistants to interact with your Anki flashcards",
   "author": "Anatoly Tarnavsky",
   "private": false,
@@ -61,7 +61,7 @@
     "@modelcontextprotocol/server": "2.0.0",
     "@nestjs/common": "^11.1.29",
     "@nestjs/config": "^4.0.4",
-    "@nestjs/core": "11.1.29",
+    "@nestjs/core": "^11.1.29",
     "@nestjs/microservices": "^11.1.29",
     "@nestjs/platform-express": "^11.1.29",
     "@rekog/mcp-nest": "^2.0.0",


### PR DESCRIPTION
Fixes #56.

## Problem
`@nestjs/core` was exact-pinned at `11.1.29` while `@nestjs/common`, `@nestjs/microservices` and `@nestjs/platform-express` floated on `^11.1.29`. Nest packages consume each other's internal modules, so every fresh `npm i` / `npx` install resolved `microservices` to 11.2.3, which requires `@nestjs/core/helpers/safe-instance-decorator` (core ≥ 11.2.2 only) → `MODULE_NOT_FOUND` at require-time, before any transport opens. Both stdio and HTTP entry points affected.

CI never saw it: `npm ci` honours the repo lockfile (all at 11.1.29), which consumers never receive.

## Fix
- `@nestjs/core` → `^11.1.29`, so the whole `@nestjs/*` runtime set shares one range and moves together
- Lockfile re-resolved: common/core/microservices/platform-express/testing all at 11.2.3; no other packages touched
- Version → 0.24.2

## Verification
- Lint, type-check, build, full unit suite (75 suites / 1320 tests) pass
- Lockfile-free consumer path: `npm pack` → install into a temp prefix → core & microservices both 11.2.3 → `dist/main-stdio.js` boots and answers `initialize`. This is the exact path that broke in #56.

## Follow-up
A CI smoke test that installs from the packed tarball without the lockfile (as suggested in #56) lands in a separate PR.

Thanks to @sudoleg for the precise report, root-cause analysis and verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLHUqkptmARkLmNPhXXTLN
