### PR TITLE
ci: lockfile-free pack smoke test; fix(http): honour PORT/HOST/ANKI_CONNECT_URL env vars

### DIFF
--- a/.github/workflows/e2e-npm-package.yml
+++ b/.github/workflows/e2e-npm-package.yml
@@ -8,6 +8,25 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 jobs:
+  pack-smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Smoke-test packed tarball (no lockfile, mirrors a real consumer install)
+      run: npm run smoke:pack
+
   e2e-npm-package:
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ npm run test:tools               # Tool unit tests only
 npm run test:workflows           # Multi-tool workflow scenarios (mocked)
 npm run test:cov                 # With coverage (70% threshold)
 npm run e2e:full:local           # One-shot E2E: up → test → down
+npm run smoke:pack               # Pack + install from tarball (no lockfile), verify initialize/tools-list
 
 # Quality
 npm run lint && npm run type-check   # Pre-push checks (also runs via Husky)

--- a/README.md
+++ b/README.md
@@ -352,9 +352,9 @@ Options:
   --tunnel [url]                 Connect via the managed tunnel (authenticated)
   --login                        Authenticate for tunnel mode (OAuth device flow)
   --logout                       Clear saved tunnel credentials
-  -p, --port <port>              Port to listen on (HTTP mode, default: 3000)
-  -h, --host <host>              Host to bind to (HTTP mode, default: 127.0.0.1)
-  -a, --anki-connect <url>       AnkiConnect URL (default: http://localhost:8765)
+  -p, --port <number>            Port to listen on (HTTP mode; default: 3000, or PORT env var)
+  -h, --host <address>           Host to bind to (HTTP mode; default: 127.0.0.1, or HOST env var)
+  -a, --anki-connect <url>       AnkiConnect URL (default: http://localhost:8765, or ANKI_CONNECT_URL env var)
   --ngrok                        Start ngrok tunnel (requires global ngrok installation)
   --read-only                    Run in read-only mode (blocks all write operations)
   --help                         Show help message
@@ -459,6 +459,8 @@ For more details, see the [official MCP documentation](https://modelcontextproto
 | `ANKI_CONNECT_API_KEY` | API key if configured in AnkiConnect | - |
 | `ANKI_CONNECT_TIMEOUT` | Request timeout in ms | `5000` |
 | `READ_ONLY` | Enable read-only mode (`true` or `1`) | `false` |
+| `PORT` | HTTP mode: port to listen on (`--port` flag takes precedence) | `3000` |
+| `HOST` | HTTP mode: address to bind to (`--host` flag takes precedence) | `127.0.0.1` |
 | `ALLOWED_HOSTS` | HTTP mode: extra `Host` header values to accept beyond loopback (comma-separated hostnames). Required when binding to a LAN/public address or running behind a reverse proxy. See [HTTP Mode Configuration](#http-mode-configuration). | loopback only |
 | `ALLOWED_ORIGINS` | HTTP mode: comma-separated allowlist of browser `Origin`/`Referer` patterns (wildcards supported, e.g. `https://*.ngrok.io`). | `http://localhost:*,http://127.0.0.1:*,https://localhost:*,https://127.0.0.1:*` |
 | `TUNNEL_SERVER_URL` | Tunnel server WebSocket URL (tunnel mode only) | `wss://tunnel.ankimcp.ai` |

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "e2e:test:http": "jest --config test/e2e/jest-e2e.config.js --testPathPatterns='http\\.e2e-spec'",
     "e2e:test:stdio": "jest --config test/e2e/jest-e2e.config.js --testPathPatterns='stdio\\.e2e-spec'",
     "e2e:full:local": "./scripts/e2e-full.sh",
+    "smoke:pack": "npm run build && bash scripts/smoke-test-pack.sh",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist dist-stdio dist-http node_modules",
     "inspector:stdio": "./node_modules/.bin/mcp-inspector --config mcp-inspector-config.json --server stdio-server",

--- a/scripts/smoke-test-pack.sh
+++ b/scripts/smoke-test-pack.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Smoke-tests the published npm package the way a real consumer installs it:
+# `npm pack` + `npm install <tarball>` with no lockfile in play, then confirms
+# the STDIO server boots and answers `initialize` / `tools/list` without needing
+# Anki/AnkiConnect to be reachable. Regression coverage for #56 (mixed
+# @nestjs/* pinning resolved to an inconsistent tree outside the repo lockfile).
+set -euo pipefail
+
+# Pick a bounded-timeout runner. `timeout` is standard on Linux CI (coreutils);
+# macOS ships neither `timeout` nor `gtimeout` by default (gtimeout comes from
+# `brew install coreutils`). Fall back to perl's alarm as a last resort so this
+# script also runs locally on macOS.
+if command -v timeout >/dev/null 2>&1; then
+  RUN_WITH_TIMEOUT=(timeout)
+elif command -v gtimeout >/dev/null 2>&1; then
+  RUN_WITH_TIMEOUT=(gtimeout)
+else
+  RUN_WITH_TIMEOUT=(perl -e 'alarm shift @ARGV; exec @ARGV or die $!')
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+dump_streams_and_fail() {
+  echo "ERROR: $1" >&2
+  echo "--- stdout ---" >&2
+  echo "${OUTPUT-}" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/stderr.log" >&2
+  exit 1
+}
+
+echo "=== Pack ==="
+npm pack --pack-destination "$TMP_DIR" >/dev/null
+TARBALL="$(ls "$TMP_DIR"/*.tgz)"
+echo "Packed: $TARBALL"
+
+echo ""
+echo "=== Install (no lockfile, mirrors a real consumer's npm install) ==="
+INSTALL_DIR="$TMP_DIR/inst"
+mkdir -p "$INSTALL_DIR"
+npm install "$TARBALL" --prefix "$INSTALL_DIR" --no-save >/dev/null
+
+SERVER_BIN="$INSTALL_DIR/node_modules/.bin/ankimcp"
+if [ ! -x "$SERVER_BIN" ]; then
+  echo "ERROR: $SERVER_BIN not found (or not executable) after install" >&2
+  exit 1
+fi
+
+HTTP_ENTRY="$INSTALL_DIR/node_modules/@ankimcp/anki-mcp-server/dist/main-http.js"
+if [ ! -f "$HTTP_ENTRY" ]; then
+  echo "ERROR: $HTTP_ENTRY not found after install" >&2
+  exit 1
+fi
+
+echo ""
+echo "=== Require HTTP entry point (validates its require graph: express, etc.) ==="
+# main-http.js bootstraps and starts listening as soon as it's required, so
+# there's no clean "load without running" check available here. Bound it with
+# a timeout instead: a bare require crash (e.g. MODULE_NOT_FOUND, or the
+# bootstrap's own catch handler calling process.exit(1)) fails fast; reaching
+# the timeout means it got past module resolution and into listen(), which is
+# what we're actually verifying.
+#
+# Must run as a script with real CLI flags, not `node -e "require(...)"` —
+# Commander parses argv from process.argv, and `node -e` mangles slicing so
+# --port/--host never reach it, silently falling back to the 3000/127.0.0.1
+# defaults and making this check bind the wrong port.
+set +e
+HTTP_OUTPUT="$(NO_UPDATE_NOTIFIER=1 "${RUN_WITH_TIMEOUT[@]}" 5 node "$HTTP_ENTRY" --port 39217 --host 127.0.0.1 2>&1)"
+HTTP_EXIT=$?
+set -e
+
+if echo "$HTTP_OUTPUT" | grep -q "MODULE_NOT_FOUND"; then
+  echo "ERROR: MODULE_NOT_FOUND detected while requiring main-http.js" >&2
+  echo "$HTTP_OUTPUT" >&2
+  exit 1
+fi
+
+if [ $HTTP_EXIT -ne 0 ] && [ $HTTP_EXIT -ne 124 ] && [ $HTTP_EXIT -ne 142 ]; then
+  echo "ERROR: main-http.js failed to boot (exit $HTTP_EXIT)" >&2
+  echo "$HTTP_OUTPUT" >&2
+  exit 1
+fi
+echo "main-http.js require OK (booted and started listening, or ran to the bounded timeout with no MODULE_NOT_FOUND)"
+
+echo ""
+echo "=== Boot server and exercise initialize + tools/list over STDIO ==="
+
+REQUESTS_FILE="$TMP_DIR/requests.jsonl"
+cat >"$REQUESTS_FILE" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.0.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+EOF
+
+set +e
+OUTPUT="$(NO_UPDATE_NOTIFIER=1 "${RUN_WITH_TIMEOUT[@]}" 10 "$SERVER_BIN" --stdio <"$REQUESTS_FILE" 2>"$TMP_DIR/stderr.log")"
+EXIT_CODE=$?
+set -e
+
+# 124 (timeout) / 142 (perl alarm's SIGALRM exit) are expected: the server
+# never exits on its own while serving stdio, so it's killed once the timeout
+# elapses. 10s is plenty of headroom for initialize + tools/list to complete.
+if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 124 ] && [ $EXIT_CODE -ne 142 ]; then
+  echo "ERROR: server exited with code $EXIT_CODE" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/stderr.log" >&2
+  exit 1
+fi
+
+if echo "$OUTPUT" | grep -q "MODULE_NOT_FOUND"; then
+  echo "ERROR: MODULE_NOT_FOUND detected in server output" >&2
+  echo "$OUTPUT" >&2
+  exit 1
+fi
+
+extract_response() {
+  jq -c --argjson id "$1" 'select(.id == $id)' <<<"$OUTPUT" 2>"$TMP_DIR/jq-err.log"
+}
+
+if ! INIT_LINE="$(extract_response 1)"; then
+  dump_streams_and_fail "stdout did not parse as JSON-RPC while looking for the initialize response ($(cat "$TMP_DIR/jq-err.log"))"
+fi
+if [ -z "$INIT_LINE" ]; then
+  dump_streams_and_fail "no response to initialize request"
+fi
+
+SERVER_NAME="$(echo "$INIT_LINE" | jq -r '.result.serverInfo.name // empty')"
+if [ -z "$SERVER_NAME" ]; then
+  echo "ERROR: initialize response missing result.serverInfo" >&2
+  echo "$INIT_LINE" >&2
+  exit 1
+fi
+echo "initialize OK - serverInfo.name=$SERVER_NAME"
+
+if ! TOOLS_LINE="$(extract_response 2)"; then
+  dump_streams_and_fail "stdout did not parse as JSON-RPC while looking for the tools/list response ($(cat "$TMP_DIR/jq-err.log"))"
+fi
+if [ -z "$TOOLS_LINE" ]; then
+  dump_streams_and_fail "no response to tools/list request"
+fi
+
+TOOL_COUNT="$(echo "$TOOLS_LINE" | jq -r '.result.tools | length')"
+if [ -z "$TOOL_COUNT" ] || [ "$TOOL_COUNT" -eq 0 ]; then
+  echo "ERROR: tools/list returned an empty tools array" >&2
+  echo "$TOOLS_LINE" >&2
+  exit 1
+fi
+
+echo "tools/list OK - $TOOL_COUNT tools"
+echo ""
+echo "=== Smoke test passed ==="

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -1,7 +1,7 @@
 import {
   parseCliArgs,
   parseOptionalUrl,
-  CliOptions,
+  BannerOptions,
   displayStartupBanner,
 } from "../cli";
 import { createCli, type Cli } from "../cli/cli-output";
@@ -29,9 +29,9 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options).toEqual({
-        port: 3000,
-        host: "127.0.0.1",
-        ankiConnect: "http://localhost:8765",
+        port: undefined,
+        host: undefined,
+        ankiConnect: undefined,
         ngrok: false,
         readOnly: false,
         login: false,
@@ -47,8 +47,8 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options.port).toBe(8080);
-      expect(options.host).toBe("127.0.0.1"); // defaults
-      expect(options.ankiConnect).toBe("http://localhost:8765"); // defaults
+      expect(options.host).toBeUndefined(); // no CLI default; Zod schema owns it
+      expect(options.ankiConnect).toBeUndefined(); // no CLI default; Zod schema owns it
     });
 
     it("should parse short form port option", () => {
@@ -65,8 +65,8 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options.host).toBe("0.0.0.0");
-      expect(options.port).toBe(3000); // defaults
-      expect(options.ankiConnect).toBe("http://localhost:8765"); // defaults
+      expect(options.port).toBeUndefined(); // no CLI default; Zod schema owns it
+      expect(options.ankiConnect).toBeUndefined(); // no CLI default; Zod schema owns it
     });
 
     it("should parse short form host option", () => {
@@ -88,8 +88,8 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options.ankiConnect).toBe("http://192.168.1.50:8765");
-      expect(options.port).toBe(3000); // defaults
-      expect(options.host).toBe("127.0.0.1"); // defaults
+      expect(options.port).toBeUndefined(); // no CLI default; Zod schema owns it
+      expect(options.host).toBeUndefined(); // no CLI default; Zod schema owns it
     });
 
     it("should parse short form anki-connect option", () => {
@@ -150,8 +150,8 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options.readOnly).toBe(true);
-      expect(options.port).toBe(3000); // defaults
-      expect(options.host).toBe("127.0.0.1"); // defaults
+      expect(options.port).toBeUndefined(); // no CLI default; Zod schema owns it
+      expect(options.host).toBeUndefined(); // no CLI default; Zod schema owns it
     });
 
     it("should parse --tunnel flag alone as true", () => {
@@ -160,8 +160,8 @@ describe("CLI Module", () => {
       const options = parseCliArgs();
 
       expect(options.tunnel).toBe(true);
-      expect(options.port).toBe(3000); // defaults
-      expect(options.host).toBe("127.0.0.1"); // defaults
+      expect(options.port).toBeUndefined(); // no CLI default; Zod schema owns it
+      expect(options.host).toBeUndefined(); // no CLI default; Zod schema owns it
     });
 
     it("should parse --read-only with other options", () => {
@@ -347,16 +347,11 @@ describe("CLI Module", () => {
     it("should display startup banner with correct information", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 3000,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -377,16 +372,11 @@ describe("CLI Module", () => {
     it("should display custom options in banner", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 8080,
         host: "0.0.0.0",
         ankiConnect: "http://192.168.1.100:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -404,16 +394,11 @@ describe("CLI Module", () => {
     it("should include remote-access hint (tunnel recommended, ngrok mentioned)", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 3000,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -429,16 +414,11 @@ describe("CLI Module", () => {
     it("should not show verbose ngrok setup steps", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 8080,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -454,16 +434,11 @@ describe("CLI Module", () => {
     it("should include help command reference", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 3000,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -478,16 +453,11 @@ describe("CLI Module", () => {
     it("should show read-only warning when enabled", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 3000,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: true,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);
@@ -503,16 +473,11 @@ describe("CLI Module", () => {
     it("should not show read-only warning when disabled", () => {
       const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-      const options: CliOptions = {
+      const options: BannerOptions = {
         port: 3000,
         host: "127.0.0.1",
         ankiConnect: "http://localhost:8765",
-        ngrok: false,
         readOnly: false,
-        login: false,
-        logout: false,
-        tunnel: false,
-        debug: false,
       };
 
       displayStartupBanner(createCli(false), options);

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -300,6 +300,45 @@ describe("CLI Module", () => {
 
       expect(options.logout).toBe(true);
     });
+
+    it("rejects an empty --anki-connect value with a Commander usage error instead of silently falling back to the default", () => {
+      process.argv = ["node", "ankimcp", "--anki-connect", ""];
+
+      const writeSpy = jest.spyOn(process.stderr, "write").mockImplementation();
+      const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called");
+      }) as never);
+
+      try {
+        expect(() => parseCliArgs()).toThrow("process.exit called");
+
+        const output = writeSpy.mock.calls.map((call) => call[0]).join("");
+        expect(output).toMatch(/AnkiConnect URL cannot be empty/);
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      } finally {
+        writeSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    });
+
+    it("rejects an empty -a value with a Commander usage error", () => {
+      process.argv = ["node", "ankimcp", "-a", ""];
+
+      const writeSpy = jest.spyOn(process.stderr, "write").mockImplementation();
+      const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called");
+      }) as never);
+
+      try {
+        expect(() => parseCliArgs()).toThrow("process.exit called");
+
+        const output = writeSpy.mock.calls.map((call) => call[0]).join("");
+        expect(output).toMatch(/AnkiConnect URL cannot be empty/);
+      } finally {
+        writeSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    });
   });
 
   describe("getVersion", () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,15 +6,48 @@ import { formatBanner, type Cli } from "./cli-output";
 import { getVersion } from "../version";
 
 export interface CliOptions {
-  port: number;
-  host: string;
-  ankiConnect: string;
+  port: number | undefined;
+  host: string | undefined;
+  ankiConnect: string | undefined;
   ngrok: boolean;
   readOnly: boolean;
   login: string | boolean;
   logout: boolean;
   tunnel: string | boolean;
   debug: boolean;
+}
+
+/**
+ * Raw shape Commander hands back from `program.opts()`. All flag values are
+ * strings (or booleans for boolean flags) at this point — no parsing/coercion
+ * has happened yet, and any flag the user didn't pass is `undefined` (none of
+ * our options carry a Commander-level default; PORT/HOST/ANKI_CONNECT_URL
+ * defaults live in the Zod schema so env vars aren't clobbered).
+ */
+interface RawCliOptions {
+  stdio?: boolean;
+  port?: string;
+  host?: string;
+  ankiConnect?: string;
+  ngrok?: boolean;
+  readOnly?: boolean;
+  login?: string | boolean;
+  logout?: boolean;
+  tunnel?: string | boolean;
+  debug?: boolean;
+}
+
+/**
+ * Resolved fields the startup banner needs. Unlike {@link CliOptions}, these
+ * are the *post-validation* values (CLI flag, env var, or Zod schema default
+ * — whichever won), so a caller can't accidentally hand the banner an
+ * unresolved `undefined` port/host/ankiConnect straight from `CliOptions`.
+ */
+export interface BannerOptions {
+  port: number;
+  host: string;
+  ankiConnect: string;
+  readOnly: boolean;
 }
 
 function getPackageJson() {
@@ -92,12 +125,17 @@ export function parseCliArgs(): CliOptions {
       "--stdio",
       "Run in STDIO mode (for MCP clients like Cursor, Cline, Zed)",
     )
-    .option("-p, --port <number>", "Port to listen on (HTTP mode)", "3000")
-    .option("-h, --host <address>", "Host to bind to (HTTP mode)", "127.0.0.1")
+    .option(
+      "-p, --port <number>",
+      "Port to listen on (HTTP mode; default: 3000, or PORT env var)",
+    )
+    .option(
+      "-h, --host <address>",
+      "Host to bind to (HTTP mode; default: 127.0.0.1, or HOST env var)",
+    )
     .option(
       "-a, --anki-connect <url>",
-      "AnkiConnect URL",
-      "http://localhost:8765",
+      "AnkiConnect URL (default: http://localhost:8765, or ANKI_CONNECT_URL env var)",
     )
     .option(
       "--ngrok",
@@ -170,10 +208,14 @@ Tunnel Mode:
 
   program.parse();
 
-  const options = program.opts<CliOptions>();
+  const options = program.opts<RawCliOptions>();
 
   return {
-    port: parseInt(options.port.toString(), 10),
+    // No Commander default here: absence must stay `undefined` so
+    // buildConfigInput() lets PORT/HOST/ANKI_CONNECT_URL env vars apply. The
+    // Zod schema (config.schema.ts) owns the 3000 / 127.0.0.1 /
+    // http://localhost:8765 defaults.
+    port: options.port !== undefined ? parseInt(options.port, 10) : undefined,
     host: options.host,
     ankiConnect: options.ankiConnect,
     ngrok: options.ngrok || false,
@@ -187,7 +229,7 @@ Tunnel Mode:
 
 export function displayStartupBanner(
   cli: Cli,
-  options: CliOptions,
+  options: BannerOptions,
   ngrokUrl?: string,
 ): void {
   const readOnlyWarning = options.readOnly

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { readFileSync } from "fs";
 import { join } from "path";
 import updateNotifier from "update-notifier";
@@ -62,6 +62,24 @@ function getPackageJson() {
 
 export function checkForUpdates(): void {
   updateNotifier({ pkg: getPackageJson() }).notify();
+}
+
+/**
+ * Parser for the `-a, --anki-connect <url>` option. Commander already
+ * requires a value for `<url>` (rejects a bare `-a`), but an explicit empty
+ * string (e.g. `-a ""` from a shell expansion of an unset env var) is a
+ * user-supplied override intent that would otherwise flow through
+ * `buildConfigInput` as `ANKI_CONNECT_URL=""` and silently resolve to the
+ * schema default. Throwing here surfaces a proper Commander usage error
+ * instead (mirrors the `--tunnel`/`--login` handling below).
+ */
+function parseAnkiConnectArg(value: string): string {
+  if (value.trim() === "") {
+    throw new InvalidArgumentError(
+      "AnkiConnect URL cannot be empty. Omit --anki-connect/-a to use the default (http://localhost:8765) or the ANKI_CONNECT_URL env var.",
+    );
+  }
+  return value;
 }
 
 /**
@@ -136,6 +154,7 @@ export function parseCliArgs(): CliOptions {
     .option(
       "-a, --anki-connect <url>",
       "AnkiConnect URL (default: http://localhost:8765, or ANKI_CONNECT_URL env var)",
+      parseAnkiConnectArg,
     )
     .option(
       "--ngrok",

--- a/src/config/__tests__/config.factory.spec.ts
+++ b/src/config/__tests__/config.factory.spec.ts
@@ -338,6 +338,38 @@ describe("Config Factory", () => {
 
       expect(config.host).toBe("127.0.0.1");
     });
+
+    it("falls back to the default AnkiConnect URL when ANKI_CONNECT_URL is a blank string", () => {
+      process.env.ANKI_CONNECT_URL = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.ankiConnect.url).toBe("http://localhost:8765");
+    });
+
+    it("falls back to the default tunnel server URL when TUNNEL_SERVER_URL is a blank string", () => {
+      process.env.TUNNEL_SERVER_URL = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.tunnel.serverUrl).toBe("wss://tunnel.ankimcp.ai");
+    });
+
+    it("falls back to the default AnkiConnect API version when ANKI_CONNECT_API_VERSION is a blank string", () => {
+      process.env.ANKI_CONNECT_API_VERSION = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.ankiConnect.apiVersion).toBe(6);
+    });
+
+    it("falls back to the default AnkiConnect timeout when ANKI_CONNECT_TIMEOUT is a blank string", () => {
+      process.env.ANKI_CONNECT_TIMEOUT = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.ankiConnect.timeout).toBe(5000);
+    });
   });
 
   describe("loadValidatedConfig", () => {

--- a/src/config/__tests__/config.factory.spec.ts
+++ b/src/config/__tests__/config.factory.spec.ts
@@ -224,6 +224,122 @@ describe("Config Factory", () => {
     });
   });
 
+  /**
+   * Regression coverage for the PORT/HOST env var bug: Commander previously
+   * gave --port/--host hardcoded defaults ("3000" / "127.0.0.1"), so
+   * cliOverrides.port/host were *never* undefined and buildConfigInput()
+   * always overrode PORT/HOST, silently ignoring the env vars. Precedence
+   * must be CLI flag > env var > schema default.
+   */
+  describe("PORT/HOST precedence (CLI flag > env var > schema default)", () => {
+    it("uses PORT/HOST env vars when no CLI flag is given", () => {
+      process.env.PORT = "39218";
+      process.env.HOST = "0.0.0.0";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.port).toBe(39218);
+      expect(config.host).toBe("0.0.0.0");
+    });
+
+    it("CLI flag overrides PORT/HOST env vars when both are set", () => {
+      process.env.PORT = "39218";
+      process.env.HOST = "0.0.0.0";
+
+      const config = loadValidatedConfig({ port: 9999, host: "192.168.1.1" });
+
+      expect(config.port).toBe(9999);
+      expect(config.host).toBe("192.168.1.1");
+    });
+
+    it("falls back to the schema default (3000 / 127.0.0.1) when neither CLI flag nor env var is set", () => {
+      delete process.env.PORT;
+      delete process.env.HOST;
+
+      const config = loadValidatedConfig({});
+
+      expect(config.port).toBe(3000);
+      expect(config.host).toBe("127.0.0.1");
+    });
+
+    it("buildConfigInput leaves PORT/HOST untouched when cliOverrides.port/host are undefined", () => {
+      process.env.PORT = "39218";
+      process.env.HOST = "0.0.0.0";
+
+      const result = buildConfigInput({ port: undefined, host: undefined });
+
+      expect(result.PORT).toBe("39218");
+      expect(result.HOST).toBe("0.0.0.0");
+    });
+  });
+
+  /**
+   * Regression coverage for the same env-var-clobber bug affecting
+   * ANKI_CONNECT_URL: Commander's `-a, --anki-connect` used to carry a
+   * hardcoded default ("http://localhost:8765"), so cliOverrides.ankiConnect
+   * was *never* undefined and buildConfigInput() always overrode
+   * ANKI_CONNECT_URL, silently ignoring the env var. Precedence must be CLI
+   * flag > env var > schema default.
+   */
+  describe("ANKI_CONNECT_URL precedence (CLI flag > env var > schema default)", () => {
+    it("uses ANKI_CONNECT_URL env var when no CLI flag is given", () => {
+      process.env.ANKI_CONNECT_URL = "http://anki.env:8765";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.ankiConnect.url).toBe("http://anki.env:8765");
+    });
+
+    it("CLI flag overrides ANKI_CONNECT_URL env var when both are set", () => {
+      process.env.ANKI_CONNECT_URL = "http://anki.env:8765";
+
+      const config = loadValidatedConfig({
+        ankiConnect: "http://anki.cli:8765",
+      });
+
+      expect(config.ankiConnect.url).toBe("http://anki.cli:8765");
+    });
+
+    it("falls back to the schema default (http://localhost:8765) when neither CLI flag nor env var is set", () => {
+      delete process.env.ANKI_CONNECT_URL;
+
+      const config = loadValidatedConfig({});
+
+      expect(config.ankiConnect.url).toBe("http://localhost:8765");
+    });
+
+    it("buildConfigInput leaves ANKI_CONNECT_URL untouched when cliOverrides.ankiConnect is undefined", () => {
+      process.env.ANKI_CONNECT_URL = "http://anki.env:8765";
+
+      const result = buildConfigInput({ ankiConnect: undefined });
+
+      expect(result.ANKI_CONNECT_URL).toBe("http://anki.env:8765");
+    });
+  });
+
+  /**
+   * Blank PORT/HOST env vars (e.g. `PORT=""` from an unset shell variable
+   * interpolated into a `.env` file) must fall through to the schema default
+   * rather than crashing coercion (PORT) or binding all interfaces (HOST).
+   */
+  describe("blank PORT/HOST env vars fall back to schema defaults", () => {
+    it("falls back to the default port when PORT is a blank string", () => {
+      process.env.PORT = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.port).toBe(3000);
+    });
+
+    it("falls back to the default host when HOST is a blank string", () => {
+      process.env.HOST = "";
+
+      const config = loadValidatedConfig({});
+
+      expect(config.host).toBe("127.0.0.1");
+    });
+  });
+
   describe("loadValidatedConfig", () => {
     it("should build and validate config in one step", () => {
       process.env.PORT = "3000";

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -18,6 +18,16 @@ export const DEFAULT_ALLOWED_ORIGINS = [
 ];
 
 /**
+ * Treats a blank/whitespace-only string as "not set" so it falls through to
+ * the schema default instead of failing coercion (PORT="") or binding an
+ * unintended value (HOST=""). Non-string values pass through unchanged.
+ */
+function emptyStringToUndefined(val: unknown): unknown {
+  if (typeof val === "string" && val.trim() === "") return undefined;
+  return val;
+}
+
+/**
  * Splits a comma-separated env string into a trimmed, non-empty list.
  * Returns the schema default ([]) when the value is absent or blank.
  */
@@ -34,8 +44,16 @@ function parseCsvList(val: unknown): string[] | undefined {
 
 export const configSchema = z.object({
   // Server
-  port: z.coerce.number().int().positive().default(3000),
-  host: z.string().default("127.0.0.1"),
+  // `.default()` must sit on the *inner* schema, not chained after
+  // `.preprocess()` — Zod 4 only re-applies `.default()` when the value
+  // reaching it is `undefined` before preprocessing runs, so chaining it
+  // outside would leave PORT="" / HOST="" as validation failures instead of
+  // falling back to the default.
+  port: z.preprocess(
+    emptyStringToUndefined,
+    z.coerce.number().int().positive().default(3000),
+  ),
+  host: z.preprocess(emptyStringToUndefined, z.string().default("127.0.0.1")),
   nodeEnv: z.enum(["development", "production", "test"]).default("development"),
 
   // MCP server identity, advertised as `serverInfo` on every transport.

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -19,8 +19,10 @@ export const DEFAULT_ALLOWED_ORIGINS = [
 
 /**
  * Treats a blank/whitespace-only string as "not set" so it falls through to
- * the schema default instead of failing coercion (PORT="") or binding an
- * unintended value (HOST=""). Non-string values pass through unchanged.
+ * the schema default instead of failing coercion (PORT="", ANKI_CONNECT_TIMEOUT="",
+ * ANKI_CONNECT_API_VERSION="") or failing `.url()` validation
+ * (ANKI_CONNECT_URL="", TUNNEL_SERVER_URL="") or binding an unintended value
+ * (HOST=""). Non-string values pass through unchanged.
  */
 function emptyStringToUndefined(val: unknown): unknown {
   if (typeof val === "string" && val.trim() === "") return undefined;
@@ -77,10 +79,19 @@ export const configSchema = z.object({
 
   // AnkiConnect
   ankiConnect: z.object({
-    url: z.string().url().default("http://localhost:8765"),
+    url: z.preprocess(
+      emptyStringToUndefined,
+      z.string().url().default("http://localhost:8765"),
+    ),
     apiKey: z.string().optional(),
-    apiVersion: z.coerce.number().int().positive().default(6),
-    timeout: z.coerce.number().int().positive().default(5000),
+    apiVersion: z.preprocess(
+      emptyStringToUndefined,
+      z.coerce.number().int().positive().default(6),
+    ),
+    timeout: z.preprocess(
+      emptyStringToUndefined,
+      z.coerce.number().int().positive().default(5000),
+    ),
   }),
 
   // Auth (generic, not Keycloak-specific)
@@ -90,7 +101,10 @@ export const configSchema = z.object({
 
   // Tunnel
   tunnel: z.object({
-    serverUrl: z.string().url().default("wss://tunnel.ankimcp.ai"),
+    serverUrl: z.preprocess(
+      emptyStringToUndefined,
+      z.string().url().default("wss://tunnel.ankimcp.ai"),
+    ),
   }),
 
   // Read-only mode

--- a/src/main-http.ts
+++ b/src/main-http.ts
@@ -72,7 +72,11 @@ async function bootstrap() {
   // arriving via the machine's LAN/public hostname will be rejected. The
   // emptiness check is sourced from the validated config (not raw process.env)
   // so CLI overrides and Zod parsing are honored.
-  const boundHost = options.host;
+  // Use the validated config's host/port (not the raw CLI options) so a
+  // value supplied via PORT/HOST env vars — rather than --port/--host — is
+  // reflected in the loopback warning, the actual listen() call, and the
+  // startup banner below.
+  const boundHost = validatedConfig.host;
   if (shouldWarnLoopbackOnly(boundHost, validatedConfig.allowedHosts)) {
     new Logger("HttpBootstrap").warn(
       `Server is bound to ${boundHost} but ALLOWED_HOSTS is not set. ` +
@@ -90,14 +94,14 @@ async function bootstrap() {
   app.connectMicroservice<CustomStrategy>({ strategy: mcpHttp.strategy });
   await app.startAllMicroservices();
 
-  await app.listen(options.port, options.host);
+  await app.listen(validatedConfig.port, validatedConfig.host);
 
   // Start ngrok if requested
   let ngrokUrl: string | undefined;
   if (options.ngrok) {
     try {
       const ngrokService = new NgrokService();
-      const tunnelInfo = await ngrokService.start(options.port);
+      const tunnelInfo = await ngrokService.start(validatedConfig.port);
       ngrokUrl = tunnelInfo.publicUrl;
     } catch (err) {
       cli.blank();
@@ -111,8 +115,21 @@ async function bootstrap() {
     }
   }
 
-  // Show startup information
-  displayStartupBanner(cli, options, ngrokUrl);
+  // Show startup information. The banner needs *resolved* values — env vars
+  // or schema defaults may have supplied port/host/ankiConnect, not just the
+  // CLI flags in `options` — so build a dedicated BannerOptions from
+  // validatedConfig rather than passing the (partially unresolved) CLI
+  // options through.
+  displayStartupBanner(
+    cli,
+    {
+      port: validatedConfig.port,
+      host: validatedConfig.host,
+      ankiConnect: validatedConfig.ankiConnect.url,
+      readOnly: validatedConfig.readOnly,
+    },
+    ngrokUrl,
+  );
 }
 
 // Bootstrap-level error handler: we don't yet have a `cli` (options weren't

--- a/src/main-stdio.ts
+++ b/src/main-stdio.ts
@@ -26,6 +26,13 @@ function parseStdioArgs(): { readOnly: boolean; ankiConnect?: string } {
     } else if (args[i] === "--anki-connect" || args[i] === "-a") {
       ankiConnect = args[i + 1];
       i++; // Skip the next arg since we consumed it
+
+      // `-a ""` would otherwise resolve silently to the default (see parseAnkiConnectArg in cli/args.ts)
+      if (ankiConnect === "") {
+        throw new Error(
+          "AnkiConnect URL cannot be empty. Omit --anki-connect/-a to use the default (http://localhost:8765) or the ANKI_CONNECT_URL env var.",
+        );
+      }
     }
   }
 

--- a/src/main-tunnel.ts
+++ b/src/main-tunnel.ts
@@ -31,7 +31,13 @@ async function bootstrap() {
   // Main tunnel mode - always runs (this is the tunnel entry point).
   // `--tunnel` is optional; only used to override the URL.
   const tunnelUrl = parseOptionalUrl(options.tunnel, "--tunnel", cli);
-  await handleTunnel(cli, tunnelUrl, options.debug, options.readOnly);
+  await handleTunnel(
+    cli,
+    tunnelUrl,
+    options.debug,
+    options.readOnly,
+    options.ankiConnect,
+  );
 }
 
 // Bootstrap-level error handler: we don't yet have a `cli` (options weren't

--- a/src/tunnel/commands/__tests__/tunnel.command.spec.ts
+++ b/src/tunnel/commands/__tests__/tunnel.command.spec.ts
@@ -82,7 +82,10 @@ jest.mock("@/app-config.service", () => ({
 }));
 
 jest.mock("@/config", () => ({
-  loadValidatedConfig: jest.fn(() => ({ tunnel: { serverUrl: "wss://x" } })),
+  loadValidatedConfig: jest.fn(() => ({
+    tunnel: { serverUrl: "wss://x" },
+    ankiConnect: { url: "http://localhost:8765" },
+  })),
 }));
 
 jest.mock("@nestjs/core", () => ({
@@ -142,6 +145,7 @@ jest.mock("@/cli/spinner", () => ({
 }));
 
 import { NestFactory } from "@nestjs/core";
+import { AppModule } from "@/app.module";
 import { handleTunnel } from "../tunnel.command";
 import {
   performLogin,
@@ -238,7 +242,28 @@ describe("handleTunnel - credential gate", () => {
       debug: false,
       readOnly: false,
       tunnel: "wss://custom.example.com",
+      ankiConnect: undefined,
     });
+  });
+
+  it("passes ankiConnect through to loadValidatedConfig and AppModule.forTunnel (so -a/--anki-connect is honoured in tunnel mode)", async () => {
+    mockLoadCredentials.mockResolvedValueOnce({ access_token: "t" });
+    await expect(
+      handleTunnel(cli, undefined, false, false, "http://192.168.1.50:8765"),
+    ).rejects.toThrow("exit");
+
+    expect(mockedLoadConfig).toHaveBeenCalledWith({
+      debug: false,
+      readOnly: false,
+      tunnel: undefined,
+      ankiConnect: "http://192.168.1.50:8765",
+    });
+    // AppModule.forTunnel throws via the mocked NestFactory, so it's called
+    // before the exit — assert it received the same override.
+    expect(AppModule.forTunnel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ankiConnect: "http://192.168.1.50:8765" }),
+    );
   });
 
   it("does NOT call performLogin when credentials already exist", async () => {
@@ -458,6 +483,11 @@ describe("handleTunnel - auto-relogin on session_expired (first connect)", () =>
     // The retry must use exactly the credentials performLogin returned.
     expect(tunnelClientStub.connect.mock.calls[1][0]).toBe(freshCreds);
     expect(cli.success).toHaveBeenCalledWith("Tunnel established");
+    // AnkiConnect URL banner line matches the HTTP mode banner's style (emoji
+    // prefix + column alignment) in cli/args.ts's displayStartupBanner().
+    expect(cli.info).toHaveBeenCalledWith(
+      "🔌 AnkiConnect URL:   http://localhost:8765",
+    );
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/src/tunnel/commands/tunnel.command.ts
+++ b/src/tunnel/commands/tunnel.command.ts
@@ -191,6 +191,9 @@ async function ensureCredentials(
  * @param debug - Optional debug mode flag (controls NestJS log levels — the
  *   `cli` parameter already has the debug flag bound for stack-trace output).
  * @param readOnly - Optional read-only mode flag
+ * @param ankiConnect - Optional AnkiConnect URL override (CLI flag > env var >
+ *   schema default). Tunnel mode still talks to AnkiConnect directly — only
+ *   the control channel to the relay goes over the tunnel.
  * @throws {Error} If connection fails
  */
 export async function handleTunnel(
@@ -198,14 +201,17 @@ export async function handleTunnel(
   tunnelUrl?: string,
   debug?: boolean,
   readOnly?: boolean,
+  ankiConnect?: string,
 ): Promise<void> {
   const credentialsService = new CredentialsService();
   // Pass tunnelUrl through to config so the device flow targets the same host
-  // as the tunnel itself (the auth endpoints are derived from this URL).
+  // as the tunnel itself (the auth endpoints are derived from this URL), and
+  // ankiConnect so `-a/--anki-connect` is honoured in tunnel mode too.
   const validatedConfig = loadValidatedConfig({
     debug,
     readOnly,
     tunnel: tunnelUrl,
+    ankiConnect,
   });
   const appConfigService = new AppConfigService(validatedConfig);
   const deviceFlowService = new DeviceFlowService(appConfigService);
@@ -292,7 +298,7 @@ export async function handleTunnel(
 
     try {
       app = await NestFactory.createMicroservice(
-        AppModule.forTunnel(mcp, { debug, readOnly }),
+        AppModule.forTunnel(mcp, { debug, readOnly, ankiConnect }),
         {
           strategy: mcp,
           logger: loggerService,
@@ -303,6 +309,7 @@ export async function handleTunnel(
       await app.listen();
       stopSpinner();
       cli.success("MCP service ready");
+      cli.info(`🔌 AnkiConnect URL:   ${validatedConfig.ankiConnect.url}`);
     } catch (error) {
       stopSpinner();
       cli.error(


### PR DESCRIPTION
Follow-up to #56 / #57 (based on that branch; retarget to `main` after #57 merges).

## 1. CI: smoke-test the packed tarball without a lockfile
CI validated the tree from `package-lock.json`, which consumers never get — the #56 crash passed every check and broke every `npx`/`npm i` user.

- `scripts/smoke-test-pack.sh` (`npm run smoke:pack`): `npm pack` → install the tarball into a temp prefix **without a lockfile** → run the real `ankimcp --stdio` bin, assert `initialize` returns `serverInfo` and `tools/list` is non-empty → boot `dist/main-http.js` on `--port 39217` under a bounded timeout to validate its require graph. Fails clearly on `MODULE_NOT_FOUND`, non-zero exit, or hang.
- New `pack-smoke-test` job in `e2e-npm-package.yml`: `npm ci` + `npm run smoke:pack`. No Docker/Anki needed, runs on PRs.
- `timeout`/`gtimeout`/perl-alarm fallback so it also runs locally on macOS.

Suggested by @sudoleg in #56 — thanks.

## 2. fix(http): `PORT`, `HOST`, `ANKI_CONNECT_URL` env vars were ignored in HTTP mode
Found while writing the smoke test: its HTTP check set `PORT=` and silently bound :3000.

Commander declared defaults for `--port`/`--host`/`--anki-connect`, so the parsed values were never `undefined` and `buildConfigInput()` always let them override the environment; `main-http.ts` also listened on raw CLI values rather than validated config. Verified on the installed 0.24.0: `PORT=39218 ankimcp` → 127.0.0.1:3000; `HOST=0.0.0.0 PORT=39220 ankimcp` → 127.0.0.1:3000. **STDIO (incl. MCPB and all README client configs) and tunnel mode were not affected.**

- Commander defaults removed; Zod schema owns defaults. Precedence: CLI flag > env var > default.
- `main-http.ts` listens on `validatedConfig.port/host`; banner prints resolved values via a `BannerOptions` type.
- `RawCliOptions` models Commander's real (string) return type.
- Blank `PORT=""`/`HOST=""` fall back to defaults (preprocess → undefined, default on the inner schema — required ordering in Zod 4).
- Precedence tests for all three vars; README env table + CLI help text synced.

## Verified
- lint / type-check / 75 suites, 1330 tests pass; shellcheck clean.
- Smoke test passes locally (48 tools), also with `:3000` deliberately occupied.
- Empirical HTTP-mode matrix on the built dist: env `PORT` honoured, flag beats env, default 3000, blank env → default, `ANKI_CONNECT_URL` reaches both banner and client (error names the configured URL), `--port abc` exits 1 with a validation error.

## Also fixed (surfaced by review)
- `ankimcp --tunnel -a <url>` was ignored — `handleTunnel` never forwarded `ankiConnect`. Tunnel startup now prints the resolved AnkiConnect URL.
- Blank `ANKI_CONNECT_URL=""`, `TUNNEL_SERVER_URL=""`, `ANKI_CONNECT_TIMEOUT=""`, `ANKI_CONNECT_API_VERSION=""` now fall back to defaults instead of failing validation.
- An explicit `-a ""` flag is rejected with a usage error (HTTP, tunnel, stdio), matching `--tunnel ""`.
- 1337 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLHUqkptmARkLmNPhXXTLN


