### PR TITLE
feat: add forgetCards and setDueDate scheduling tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- **New `forgetCards` tool** — resets cards to the new queue, discarding interval, due date and ease factor. Previously the only way to push a card back into rotation was `rate_card` with a rating of 1, which records a real review, counts as a lapse and drops the card's ease factor — corrupting both future scheduling and review statistics. The response reports each card's prior state (`previousState`, `previousIntervalDays`, `reps`, `lapses`) so callers can show what was given up. The review log is preserved; note content, tags and deck placement are untouched.
+- **New `setDueDate` tool** — reschedules cards to become due in N days without recording a review. Accepts Anki's spec format: `"0"` (today), `"5"`, `"3-7"` (a random day in range, to spread a batch out) and a trailing `!` (`"1!"`) to also overwrite the interval. Scheduling is read back after the change, so ranges report the day each card actually landed on.
+- Both tools validate every card ID via `cardsInfo` before mutating: AnkiConnect's `forgetCards` returns `null` and `setDueDate` returns `true` even for IDs that don't exist, so a typo would otherwise look like a successful reset. Shared validation lives in `src/mcp/utils/card-validation.utils.ts`.
+
 ## [0.24.0] - 2026-08
 
 - **Claude Desktop's Code tab works again** (fixes #53). Every tool call failed with `JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#")`. [SEP-1613](https://modelcontextprotocol.io/seps/1613-establish-json-schema-2020-12-as-default-dialect-f) made 2020-12 the default dialect, but `@modelcontextprotocol/sdk` 1.x hardcodes draft-07 with no opt-out, and the upstream fixes for the 1.x line have not landed — so no configuration change here could resolve it. The server now uses the v2 SDK (`@modelcontextprotocol/{core,node,server}`), and all 96 tool schemas (48 input + 48 output) emit `https://json-schema.org/draft/2020-12/schema`. Regular Desktop chat was unaffected because it does not validate the dialect; only the Code tab does.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The server exposes **42 MCP tools** — 31 essential tools for everyday Anki ope
 - `get_cards` - Get cards with flexible filtering by state (due, new, learning, suspended, buried) and deck
 - `present_card` - Show a card for review with its question/front side
 - `rate_card` - Rate card performance (Again, Hard, Good, Easy) and schedule the next review
+- `forgetCards` - Reset cards to new, discarding their scheduling without recording a review
+- `setDueDate` - Reschedule cards to become due in N days (`"0"`, `"3-7"`, `"1!"`), without recording a review
+
+> **Note:** `forgetCards` and `setDueDate` change scheduling *without* logging a review, which is what separates them from `rate_card`. Reach for them when a card's schedule is wrong rather than the answer: rating a card `Again` to bury it deeper records a real lapse and drops its ease factor, permanently skewing both future scheduling and your statistics. `forgetCards` wipes the interval and starts the card over; `setDueDate` keeps the card's history and just moves the next review.
 
 > **Note:** Card `front`/`back` content is rendered per card from its own template (as Anki shows it), so reversed and cloze cards display the correct direction. Static text added by your card templates appears in the output as well.
 

--- a/manifest.json
+++ b/manifest.json
@@ -60,6 +60,14 @@
       "description": "Rate card performance (Again, Hard, Good, Easy) and schedule next review"
     },
     {
+      "name": "forgetCards",
+      "description": "Reset cards to new, discarding their scheduling without recording a review"
+    },
+    {
+      "name": "setDueDate",
+      "description": "Reschedule cards to become due in a given number of days, without recording a review"
+    },
+    {
       "name": "addNote",
       "description": "Add a SINGLE note. To create multiple notes, use addNotes instead of calling addNote repeatedly — AnkiConnect processes requests one at a time, so repeated/parallel addNote calls are slower and unnecessary. IMPORTANT: Only create notes that were explicitly requested by the user"
     },

--- a/src/mcp/primitives/essential/index.ts
+++ b/src/mcp/primitives/essential/index.ts
@@ -21,6 +21,8 @@ export { GetDueCardsTool } from "./tools/get-due-cards.tool";
 export { GetCardsTool } from "./tools/get-cards.tool";
 export { PresentCardTool } from "./tools/present-card.tool";
 export { RateCardTool } from "./tools/rate-card.tool";
+export { ForgetCardsTool } from "./tools/forget-cards.tool";
+export { SetDueDateTool } from "./tools/set-due-date.tool";
 export { ModelNamesTool } from "./tools/model-names.tool";
 export { ModelFieldNamesTool } from "./tools/model-field-names.tool";
 export { ModelStylingTool } from "./tools/model-styling.tool";
@@ -72,6 +74,8 @@ import { GetDueCardsTool } from "./tools/get-due-cards.tool";
 import { GetCardsTool } from "./tools/get-cards.tool";
 import { PresentCardTool } from "./tools/present-card.tool";
 import { RateCardTool } from "./tools/rate-card.tool";
+import { ForgetCardsTool } from "./tools/forget-cards.tool";
+import { SetDueDateTool } from "./tools/set-due-date.tool";
 import { ModelNamesTool } from "./tools/model-names.tool";
 import { ModelFieldNamesTool } from "./tools/model-field-names.tool";
 import { ModelStylingTool } from "./tools/model-styling.tool";
@@ -116,6 +120,8 @@ export const ESSENTIAL_MCP_TOOLS = [
   GetCardsTool,
   PresentCardTool,
   RateCardTool,
+  ForgetCardsTool,
+  SetDueDateTool,
   ModelNamesTool,
   ModelFieldNamesTool,
   ModelStylingTool,

--- a/src/mcp/primitives/essential/tools/__tests__/forget-cards.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/forget-cards.tool.spec.ts
@@ -1,0 +1,154 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ForgetCardsTool } from "../forget-cards.tool";
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { parseToolResult } from "@/test-fixtures/test-helpers";
+
+jest.mock("@/mcp/clients/anki-connect.client");
+
+/**
+ * Build a fake `cardsInfo` response. Missing cards are represented the way
+ * AnkiConnect represents them — as empty objects.
+ */
+function mockCardsInfo(
+  cards: Array<{
+    cardId: number;
+    type?: number;
+    interval?: number;
+    reps?: number;
+    lapses?: number;
+  }>,
+) {
+  return cards.map((c) => ({
+    cardId: c.cardId,
+    type: c.type ?? 2,
+    interval: c.interval ?? 30,
+    reps: c.reps ?? 12,
+    lapses: c.lapses ?? 3,
+  }));
+}
+
+describe("ForgetCardsTool", () => {
+  let tool: ForgetCardsTool;
+  let ankiClient: jest.Mocked<AnkiConnectClient>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ForgetCardsTool, AnkiConnectClient],
+    }).compile();
+
+    tool = module.get<ForgetCardsTool>(ForgetCardsTool);
+    ankiClient = module.get(
+      AnkiConnectClient,
+    ) as jest.Mocked<AnkiConnectClient>;
+    jest.clearAllMocks();
+  });
+
+  it("should reset cards to new", async () => {
+    const cards = [1502098034045, 1502098034048];
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo(cards.map((cardId) => ({ cardId })))) // cardsInfo
+      .mockResolvedValueOnce(null); // forgetCards
+
+    const rawResult = await tool.execute({ cards });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).toHaveBeenNthCalledWith(1, "cardsInfo", {
+      cards,
+    });
+    expect(ankiClient.invoke).toHaveBeenNthCalledWith(2, "forgetCards", {
+      cards,
+    });
+    expect(result.success).toBe(true);
+    expect(result.cardsAffected).toBe(2);
+  });
+
+  it("should report the state each card was in before the reset", async () => {
+    const cards = [111, 222];
+    ankiClient.invoke
+      .mockResolvedValueOnce(
+        mockCardsInfo([
+          { cardId: 111, type: 2, interval: 47, reps: 9, lapses: 2 },
+          { cardId: 222, type: 0, interval: 0, reps: 0, lapses: 0 },
+        ]),
+      )
+      .mockResolvedValueOnce(null);
+
+    const rawResult = await tool.execute({ cards });
+    const result = parseToolResult(rawResult);
+
+    expect(result.reset).toEqual([
+      {
+        cardId: 111,
+        previousState: "review",
+        previousIntervalDays: 47,
+        reps: 9,
+        lapses: 2,
+      },
+      {
+        cardId: 222,
+        previousState: "new",
+        previousIntervalDays: 0,
+        reps: 0,
+        lapses: 0,
+      },
+    ]);
+  });
+
+  it("should fail when cards array is empty", async () => {
+    const rawResult = await tool.execute({ cards: [] });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cards array is required");
+  });
+
+  it("should not reset anything when a card ID does not exist", async () => {
+    const cards = [111, 222];
+    // Second card is missing — AnkiConnect returns an empty object for it.
+    ankiClient.invoke.mockResolvedValueOnce([{ cardId: 111 }, {}]);
+
+    const rawResult = await tool.execute({ cards });
+    const result = parseToolResult(rawResult);
+
+    // forgetCards must NOT fire — this is the whole point of the pre-check,
+    // since forgetCards returns null for bogus IDs too.
+    expect(ankiClient.invoke).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("222");
+    expect(result.error).toContain("No cards were reset");
+  });
+
+  it("should truncate the missing-IDs list when it is huge", async () => {
+    const bogusIds = Array.from({ length: 25 }, (_, i) => 1000 + i);
+    ankiClient.invoke.mockResolvedValueOnce(bogusIds.map(() => ({})));
+
+    const rawResult = await tool.execute({ cards: bogusIds });
+    const result = parseToolResult(rawResult);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("and 15 more");
+  });
+
+  it("should handle network errors", async () => {
+    ankiClient.invoke.mockRejectedValueOnce(new Error("Network error"));
+
+    const rawResult = await tool.execute({ cards: [1234567890] });
+    const result = parseToolResult(rawResult);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Network error");
+  });
+
+  it("should handle AnkiConnect errors on forgetCards", async () => {
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo([{ cardId: 999 }]))
+      .mockRejectedValueOnce(new Error("collection is not open"));
+
+    const rawResult = await tool.execute({ cards: [999] });
+    const result = parseToolResult(rawResult);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("collection is not open");
+  });
+});

--- a/src/mcp/primitives/essential/tools/__tests__/set-due-date.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/set-due-date.tool.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { SetDueDateTool } from "../set-due-date.tool";
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { parseToolResult } from "@/test-fixtures/test-helpers";
+
+jest.mock("@/mcp/clients/anki-connect.client");
+
+function mockCardsInfo(ids: number[], interval = 10, due = 500) {
+  return ids.map((cardId) => ({ cardId, interval, due }));
+}
+
+describe("SetDueDateTool", () => {
+  let tool: SetDueDateTool;
+  let ankiClient: jest.Mocked<AnkiConnectClient>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SetDueDateTool, AnkiConnectClient],
+    }).compile();
+
+    tool = module.get<SetDueDateTool>(SetDueDateTool);
+    ankiClient = module.get(
+      AnkiConnectClient,
+    ) as jest.Mocked<AnkiConnectClient>;
+    jest.clearAllMocks();
+  });
+
+  it("should reschedule cards", async () => {
+    const cards = [111, 222];
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo(cards)) // cardsInfo validation
+      .mockResolvedValueOnce(true) // setDueDate
+      .mockResolvedValueOnce(mockCardsInfo(cards, 0, 20500)); // cardsInfo read-back
+
+    const rawResult = await tool.execute({ cards, days: "0" });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).toHaveBeenNthCalledWith(2, "setDueDate", {
+      cards,
+      days: "0",
+    });
+    expect(result.success).toBe(true);
+    expect(result.cardsAffected).toBe(2);
+    expect(result.days).toBe("0");
+    expect(result.intervalOverwritten).toBe(false);
+  });
+
+  it("should read scheduling back after the change", async () => {
+    const cards = [111];
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo(cards))
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce([{ cardId: 111, interval: 1, due: 20777 }]);
+
+    const rawResult = await tool.execute({ cards, days: "1!" });
+    const result = parseToolResult(rawResult);
+
+    expect(result.scheduled).toEqual([
+      { cardId: 111, intervalDays: 1, due: 20777 },
+    ]);
+    expect(result.intervalOverwritten).toBe(true);
+  });
+
+  it.each(["0", "5", "3-7", "1!", "3-7!"])(
+    'should accept the days spec "%s"',
+    async (days) => {
+      ankiClient.invoke
+        .mockResolvedValueOnce(mockCardsInfo([111]))
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(mockCardsInfo([111]));
+
+      const rawResult = await tool.execute({ cards: [111], days });
+      const result = parseToolResult(rawResult);
+
+      expect(result.success).toBe(true);
+      expect(result.days).toBe(days);
+    },
+  );
+
+  it.each(["tomorrow", "-3", "3..7", "", "1!!", "3-"])(
+    'should reject the days spec "%s"',
+    async (days) => {
+      const rawResult = await tool.execute({ cards: [111], days });
+      const result = parseToolResult(rawResult);
+
+      expect(ankiClient.invoke).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it("should reject a backwards range", async () => {
+    const rawResult = await tool.execute({ cards: [111], days: "7-3" });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("must not be");
+  });
+
+  it("should trim whitespace around the days spec", async () => {
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo([111]))
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(mockCardsInfo([111]));
+
+    const rawResult = await tool.execute({ cards: [111], days: "  3-7  " });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).toHaveBeenNthCalledWith(2, "setDueDate", {
+      cards: [111],
+      days: "3-7",
+    });
+    expect(result.days).toBe("3-7");
+  });
+
+  it("should fail when cards array is empty", async () => {
+    const rawResult = await tool.execute({ cards: [], days: "0" });
+    const result = parseToolResult(rawResult);
+
+    expect(ankiClient.invoke).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cards array is required");
+  });
+
+  it("should not reschedule anything when a card ID does not exist", async () => {
+    ankiClient.invoke.mockResolvedValueOnce([{ cardId: 111 }, {}]);
+
+    const rawResult = await tool.execute({ cards: [111, 222], days: "0" });
+    const result = parseToolResult(rawResult);
+
+    // setDueDate returns true even for bogus IDs, so the pre-check must stop it.
+    expect(ankiClient.invoke).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("222");
+    expect(result.error).toContain("No cards were rescheduled");
+  });
+
+  it("should handle network errors", async () => {
+    ankiClient.invoke.mockRejectedValueOnce(new Error("Network error"));
+
+    const rawResult = await tool.execute({ cards: [111], days: "0" });
+    const result = parseToolResult(rawResult);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Network error");
+  });
+});

--- a/src/mcp/primitives/essential/tools/__tests__/set-due-date.tool.spec.ts
+++ b/src/mcp/primitives/essential/tools/__tests__/set-due-date.tool.spec.ts
@@ -144,4 +144,21 @@ describe("SetDueDateTool", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("Network error");
   });
+
+  it("should still report success when the read-back fails after the reschedule", async () => {
+    ankiClient.invoke
+      .mockResolvedValueOnce(mockCardsInfo([111])) // cardsInfo validation
+      .mockResolvedValueOnce(true) // setDueDate — committed
+      .mockRejectedValueOnce(new Error("Anki closed")); // cardsInfo read-back
+
+    const rawResult = await tool.execute({ cards: [111], days: "3-7" });
+    const result = parseToolResult(rawResult);
+
+    // The mutation landed, so reporting it as a failure would invite a retry —
+    // and retrying a range spec re-rolls the dates.
+    expect(result.success).toBe(true);
+    expect(result.cardsAffected).toBe(1);
+    expect(result.scheduled).toEqual([]);
+    expect(result.message).toContain("do not retry");
+  });
 });

--- a/src/mcp/primitives/essential/tools/forget-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/forget-cards.tool.ts
@@ -30,8 +30,8 @@ export class ForgetCardsTool {
         .array(z.number())
         .min(1)
         .describe(
-          "Array of card IDs to reset to new. Card IDs (not note IDs) — use findCards, " +
-            "get_cards, or notesInfo to obtain them.",
+          "Array of card IDs to reset to new. Card IDs (not note IDs) — use get_cards, " +
+            "get_due_cards, or notesInfo to obtain them.",
         ),
     }),
     outputSchema: z.object({

--- a/src/mcp/primitives/essential/tools/forget-cards.tool.ts
+++ b/src/mcp/primitives/essential/tools/forget-cards.tool.ts
@@ -1,0 +1,127 @@
+import { Logger } from "@nestjs/common";
+import { Payload } from "@nestjs/microservices";
+import { McpController, Tool } from "@rekog/mcp-nest";
+import { z } from "zod";
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { createErrorResponse, getCardType } from "@/mcp/utils/anki.utils";
+import { fetchExistingCards } from "@/mcp/utils/card-validation.utils";
+
+/**
+ * Tool for resetting cards back to the new queue.
+ */
+@McpController()
+export class ForgetCardsTool {
+  private readonly logger = new Logger(ForgetCardsTool.name);
+
+  constructor(private readonly ankiClient: AnkiConnectClient) {}
+
+  @Tool({
+    name: "forgetCards",
+    description:
+      "Reset cards to the new queue, discarding their current scheduling (interval, due date, and ease factor). " +
+      "Use this when a card should be relearned from scratch — for example when the user keeps failing to recall " +
+      "a word that Anki has scheduled months out. Prefer this over rating a card 'Again': a rating records a real " +
+      "review and counts as a lapse, which distorts both future scheduling and the collection's statistics. " +
+      "The review log is preserved, so past reviews still show in card info and statistics. " +
+      "This changes scheduling only — note content, tags, and deck placement are untouched. " +
+      "Cards that are already new are unaffected, so re-running is safe.",
+    parameters: z.object({
+      cards: z
+        .array(z.number())
+        .min(1)
+        .describe(
+          "Array of card IDs to reset to new. Card IDs (not note IDs) — use findCards, " +
+            "get_cards, or notesInfo to obtain them.",
+        ),
+    }),
+    outputSchema: z.object({
+      success: z.boolean(),
+      message: z.string(),
+      cardsAffected: z.number(),
+      reset: z
+        .array(
+          z.object({
+            cardId: z.number(),
+            previousState: z
+              .string()
+              .describe(
+                "Card state before the reset: new, learning, review, or relearning",
+              ),
+            previousIntervalDays: z
+              .number()
+              .describe(
+                "Scheduling interval in days before the reset (0 for new cards)",
+              ),
+            reps: z
+              .number()
+              .describe(
+                "Total reviews logged for the card (unchanged by the reset)",
+              ),
+            lapses: z
+              .number()
+              .describe(
+                "Total lapses logged for the card (unchanged by the reset)",
+              ),
+          }),
+        )
+        .describe(
+          "Per-card state captured immediately before the reset, so the caller can report " +
+            "what was given up.",
+        ),
+    }),
+    annotations: {
+      title: "Reset Cards to New",
+      readOnlyHint: false,
+      // Scheduling progress is discarded and only Anki's own undo can restore it.
+      destructiveHint: true,
+      // Resetting an already-new card is a no-op.
+      idempotentHint: true,
+    },
+  })
+  async execute(@Payload() params: { cards: number[] }) {
+    const cards = params?.cards ?? [];
+
+    try {
+      this.logger.log(`Executing forgetCards: ${cards.length} card(s)`);
+
+      if (cards.length === 0) {
+        throw new Error("cards array is required for forgetCards action");
+      }
+
+      // Capture state before the reset. This doubles as ID validation:
+      // AnkiConnect's forgetCards returns null whether or not the cards exist.
+      const cardsInfo = await fetchExistingCards(
+        cards,
+        this.ankiClient,
+        "No cards were reset.",
+      );
+
+      const reset = cardsInfo.map((card) => ({
+        cardId: card.cardId,
+        previousState: getCardType(card.type ?? -1),
+        previousIntervalDays: card.interval ?? 0,
+        reps: card.reps ?? 0,
+        lapses: card.lapses ?? 0,
+      }));
+
+      // forgetCards returns null on success.
+      await this.ankiClient.invoke<null>("forgetCards", { cards });
+
+      this.logger.log(`Reset ${cards.length} card(s) to new`);
+
+      return {
+        success: true,
+        message: `Successfully reset ${cards.length} card(s) to new`,
+        cardsAffected: cards.length,
+        reset,
+      };
+    } catch (error) {
+      this.logger.error("Failed to execute forgetCards", error);
+      return createErrorResponse(error, {
+        action: "forgetCards",
+        cardIds: cards,
+        hint: "Make sure Anki is running and the card IDs are valid card IDs (not note IDs)",
+      });
+    }
+  }
+}

--- a/src/mcp/primitives/essential/tools/set-due-date.tool.ts
+++ b/src/mcp/primitives/essential/tools/set-due-date.tool.ts
@@ -38,8 +38,8 @@ export class SetDueDateTool {
         .array(z.number())
         .min(1)
         .describe(
-          "Array of card IDs to reschedule. Card IDs (not note IDs) — use findCards, " +
-            "get_cards, or notesInfo to obtain them.",
+          "Array of card IDs to reschedule. Card IDs (not note IDs) — use get_cards, " +
+            "get_due_cards, or notesInfo to obtain them.",
         ),
       days: z
         .string()
@@ -76,16 +76,22 @@ export class SetDueDateTool {
               ),
           }),
         )
-        .describe("Per-card scheduling state read back after the change"),
+        .describe(
+          "Per-card scheduling state read back after the change. Empty when the " +
+            "read-back failed — the reschedule itself still succeeded, so check " +
+            "`message` rather than treating an empty array as a no-op.",
+        ),
     }),
     annotations: {
       title: "Set Card Due Date",
       readOnlyHint: false,
       // Review history is preserved; only the next due date moves.
       destructiveHint: false,
-      // Re-applying the same absolute spec lands on the same day, except for
-      // ranges, which re-roll.
-      idempotentHint: true,
+      // A range spec like "3-7" re-rolls on every call, so repeating the same
+      // arguments can land the same cards on different days. The hint describes
+      // the tool rather than one set of arguments, and a client that auto-retries
+      // on it would silently reshuffle scheduling.
+      idempotentHint: false,
     },
   })
   async execute(@Payload() params: { cards: number[]; days: string }) {
@@ -132,27 +138,48 @@ export class SetDueDateTool {
 
       await this.ankiClient.invoke<boolean>("setDueDate", { cards, days });
 
-      // Read the scheduling back so the caller reports what Anki actually did
-      // rather than what was requested — ranges in particular resolve to a
-      // different day per card.
-      const updated = await this.ankiClient.invoke<AnkiCardInfo[]>(
-        "cardsInfo",
-        {
-          cards,
-        },
-      );
+      // The reschedule is committed from here on. Everything below is reporting,
+      // so it gets its own error handling: surfacing a read-back failure as a
+      // failed call would invite a retry, and retrying a range spec re-rolls the
+      // dates — turning a cosmetic problem into a scheduling one.
+      let scheduled: Array<{
+        cardId: number;
+        intervalDays: number;
+        due: number;
+      }> = [];
+      let readBackFailed = false;
 
-      const scheduled = cards.map((cardId, index) => ({
-        cardId,
-        intervalDays: updated?.[index]?.interval ?? 0,
-        due: updated?.[index]?.due ?? 0,
-      }));
+      try {
+        // Read the scheduling back so the caller reports what Anki actually did
+        // rather than what was requested — ranges in particular resolve to a
+        // different day per card.
+        const updated = await this.ankiClient.invoke<AnkiCardInfo[]>(
+          "cardsInfo",
+          { cards },
+        );
+
+        scheduled = cards.map((cardId, index) => ({
+          cardId,
+          intervalDays: updated?.[index]?.interval ?? 0,
+          due: updated?.[index]?.due ?? 0,
+        }));
+      } catch (readBackError) {
+        readBackFailed = true;
+        this.logger.warn(
+          `Rescheduled ${cards.length} card(s) to "${days}" but could not read ` +
+            `the new scheduling back`,
+          readBackError,
+        );
+      }
 
       this.logger.log(`Rescheduled ${cards.length} card(s) to "${days}"`);
 
       return {
         success: true,
-        message: `Successfully rescheduled ${cards.length} card(s) to "${days}"`,
+        message: readBackFailed
+          ? `Successfully rescheduled ${cards.length} card(s) to "${days}", but reading ` +
+            `the new scheduling back failed. The reschedule was applied — do not retry.`
+          : `Successfully rescheduled ${cards.length} card(s) to "${days}"`,
         cardsAffected: cards.length,
         days,
         intervalOverwritten: days.endsWith("!"),

--- a/src/mcp/primitives/essential/tools/set-due-date.tool.ts
+++ b/src/mcp/primitives/essential/tools/set-due-date.tool.ts
@@ -1,0 +1,171 @@
+import { Logger } from "@nestjs/common";
+import { Payload } from "@nestjs/microservices";
+import { McpController, Tool } from "@rekog/mcp-nest";
+import { z } from "zod";
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+import { createErrorResponse } from "@/mcp/utils/anki.utils";
+import {
+  AnkiCardInfo,
+  fetchExistingCards,
+} from "@/mcp/utils/card-validation.utils";
+
+/**
+ * Anki's due-date spec: a day count, an inclusive range, or either with a
+ * trailing `!` meaning "also set the interval to this value".
+ */
+const DAYS_SPEC = /^(\d+)(?:-(\d+))?(!?)$/;
+
+/**
+ * Tool for rescheduling cards to a specific due date without recording a review.
+ */
+@McpController()
+export class SetDueDateTool {
+  private readonly logger = new Logger(SetDueDateTool.name);
+
+  constructor(private readonly ankiClient: AnkiConnectClient) {}
+
+  @Tool({
+    name: "setDueDate",
+    description:
+      "Reschedule cards to become due in a given number of days, without recording a review. " +
+      "Use this to bring a card forward (or push it back) when its current interval doesn't match how well " +
+      "the user actually knows it — rating the card instead would log a fake review and skew its ease factor. " +
+      "Unlike forgetCards this keeps the card's existing interval and ease unless you ask otherwise, so it is " +
+      "the gentler option when the card's history is still worth keeping. " +
+      "Note that applying this to a new card turns it into a review card.",
+    parameters: z.object({
+      cards: z
+        .array(z.number())
+        .min(1)
+        .describe(
+          "Array of card IDs to reschedule. Card IDs (not note IDs) — use findCards, " +
+            "get_cards, or notesInfo to obtain them.",
+        ),
+      days: z
+        .string()
+        .describe(
+          "How many days from now the cards become due. " +
+            '"0" = today, "1" = tomorrow, "3-7" = a random day in that inclusive range ' +
+            "(spreads a batch out instead of stacking it on one day). " +
+            'Append "!" — e.g. "1!" — to also overwrite the card\'s interval with that value, ' +
+            "rather than leaving the existing interval in place.",
+        ),
+    }),
+    outputSchema: z.object({
+      success: z.boolean(),
+      message: z.string(),
+      cardsAffected: z.number(),
+      days: z.string().describe("The due-date spec that was applied"),
+      intervalOverwritten: z
+        .boolean()
+        .describe(
+          'True when the spec ended in "!", meaning the interval was reset to the day count',
+        ),
+      scheduled: z
+        .array(
+          z.object({
+            cardId: z.number(),
+            intervalDays: z
+              .number()
+              .describe("The card's interval after rescheduling"),
+            due: z
+              .number()
+              .describe(
+                "Anki's raw due value: days since collection creation for review cards, " +
+                  "a queue position for new cards, a unix timestamp for learning cards",
+              ),
+          }),
+        )
+        .describe("Per-card scheduling state read back after the change"),
+    }),
+    annotations: {
+      title: "Set Card Due Date",
+      readOnlyHint: false,
+      // Review history is preserved; only the next due date moves.
+      destructiveHint: false,
+      // Re-applying the same absolute spec lands on the same day, except for
+      // ranges, which re-roll.
+      idempotentHint: true,
+    },
+  })
+  async execute(@Payload() params: { cards: number[]; days: string }) {
+    const cards = params?.cards ?? [];
+    const rawDays = params?.days;
+
+    try {
+      this.logger.log(
+        `Executing setDueDate: ${cards.length} card(s) -> "${rawDays}"`,
+      );
+
+      if (cards.length === 0) {
+        throw new Error("cards array is required for setDueDate action");
+      }
+      if (!rawDays || rawDays.trim() === "") {
+        throw new Error("days is required for setDueDate action");
+      }
+
+      const days = rawDays.trim();
+      const match = DAYS_SPEC.exec(days);
+      if (!match) {
+        throw new Error(
+          `Invalid days spec "${days}". Expected a day count ("0", "5"), an ` +
+            'inclusive range ("3-7"), optionally suffixed with "!" to also ' +
+            'overwrite the interval ("1!").',
+        );
+      }
+
+      const [, startStr, endStr] = match;
+      if (endStr !== undefined && Number(endStr) < Number(startStr)) {
+        throw new Error(
+          `Invalid days range "${days}": the end of the range must not be ` +
+            `earlier than the start.`,
+        );
+      }
+
+      // Validate the IDs first — setDueDate returns true even for a list of
+      // card IDs that don't exist, so a typo would otherwise look like success.
+      await fetchExistingCards(
+        cards,
+        this.ankiClient,
+        "No cards were rescheduled.",
+      );
+
+      await this.ankiClient.invoke<boolean>("setDueDate", { cards, days });
+
+      // Read the scheduling back so the caller reports what Anki actually did
+      // rather than what was requested — ranges in particular resolve to a
+      // different day per card.
+      const updated = await this.ankiClient.invoke<AnkiCardInfo[]>(
+        "cardsInfo",
+        {
+          cards,
+        },
+      );
+
+      const scheduled = cards.map((cardId, index) => ({
+        cardId,
+        intervalDays: updated?.[index]?.interval ?? 0,
+        due: updated?.[index]?.due ?? 0,
+      }));
+
+      this.logger.log(`Rescheduled ${cards.length} card(s) to "${days}"`);
+
+      return {
+        success: true,
+        message: `Successfully rescheduled ${cards.length} card(s) to "${days}"`,
+        cardsAffected: cards.length,
+        days,
+        intervalOverwritten: days.endsWith("!"),
+        scheduled,
+      };
+    } catch (error) {
+      this.logger.error("Failed to execute setDueDate", error);
+      return createErrorResponse(error, {
+        action: "setDueDate",
+        cardIds: cards,
+        days: rawDays,
+        hint: 'Make sure Anki is running, the card IDs are valid card IDs (not note IDs), and days looks like "0", "5", "3-7", or "1!"',
+      });
+    }
+  }
+}

--- a/src/mcp/utils/card-validation.utils.ts
+++ b/src/mcp/utils/card-validation.utils.ts
@@ -1,0 +1,96 @@
+import { AnkiConnectClient } from "@/mcp/clients/anki-connect.client";
+
+/**
+ * The subset of AnkiConnect's `cardsInfo` payload the scheduling tools care
+ * about. Every field is optional because AnkiConnect represents a card it
+ * couldn't find as an empty object `{}` rather than omitting the slot.
+ *
+ * @see https://git.sr.ht/~foosoft/anki-connect#cardsinfo
+ */
+export interface AnkiCardInfo {
+  cardId?: number;
+  type?: number;
+  queue?: number;
+  interval?: number;
+  due?: number;
+  reps?: number;
+  lapses?: number;
+  factor?: number;
+  deckName?: string;
+}
+
+/**
+ * A `cardsInfo` entry that has been confirmed to exist.
+ */
+export type ExistingAnkiCardInfo = AnkiCardInfo & { cardId: number };
+
+/**
+ * Error thrown when one or more requested card IDs don't exist in the
+ * collection. Tool wrappers convert this into an MCP error response.
+ */
+export class MissingCardIdsError extends Error {
+  constructor(
+    public readonly missingIds: number[],
+    public readonly totalRequested: number,
+    /** Trailing clause stating that nothing changed, e.g. "No cards were reset." */
+    noOpNotice: string,
+  ) {
+    super(
+      MissingCardIdsError.buildMessage(missingIds, totalRequested, noOpNotice),
+    );
+    this.name = "MissingCardIdsError";
+  }
+
+  private static buildMessage(
+    ids: number[],
+    total: number,
+    noOpNotice: string,
+  ): string {
+    // Cap the list shown so a huge bogus input doesn't produce a massive
+    // unreadable error string.
+    const MAX_SHOWN = 10;
+    const shown = ids.slice(0, MAX_SHOWN).join(", ");
+    const suffix =
+      ids.length > MAX_SHOWN ? ` (and ${ids.length - MAX_SHOWN} more)` : "";
+    return (
+      `${ids.length} of ${total} card ID(s) do not exist in the Anki ` +
+      `collection: [${shown}]${suffix}. ${noOpNotice}`
+    );
+  }
+}
+
+/**
+ * Look up every card ID and fail unless all of them exist.
+ *
+ * The scheduling actions (`forgetCards`, `setDueDate`) report success whether
+ * or not the IDs they were given are real — `forgetCards` returns `null` and
+ * `setDueDate` returns `true` even for an empty or entirely bogus list. Without
+ * this pre-check a typo'd ID would look like a successful reset, which is the
+ * worst possible failure mode for a tool whose whole job is to change
+ * scheduling state.
+ *
+ * @param noOpNotice Clause appended to the error explaining that nothing was
+ *   changed, phrased for the calling tool (e.g. "No cards were reset.").
+ * @throws {MissingCardIdsError} When any provided card ID doesn't exist.
+ */
+export async function fetchExistingCards(
+  cards: number[],
+  client: AnkiConnectClient,
+  noOpNotice: string,
+): Promise<ExistingAnkiCardInfo[]> {
+  const cardsInfo = await client.invoke<AnkiCardInfo[]>("cardsInfo", { cards });
+
+  const missingIds: number[] = [];
+  cards.forEach((id, index) => {
+    const info = cardsInfo?.[index];
+    if (!info || typeof info.cardId !== "number") {
+      missingIds.push(id);
+    }
+  });
+
+  if (missingIds.length > 0) {
+    throw new MissingCardIdsError(missingIds, cards.length, noOpNotice);
+  }
+
+  return cardsInfo as ExistingAnkiCardInfo[];
+}


### PR DESCRIPTION
Both tools change a card's schedule without recording a review, which is what separates them from rate_card. Until now the only way to push a card back into rotation was rate_card with a rating of 1 — that logs a real review, counts as a lapse and drops the card's ease factor, permanently skewing future scheduling and review statistics.

forgetCards resets cards to the new queue and reports each card's prior state (previousState, previousIntervalDays, reps, lapses) so callers can show what was given up. setDueDate moves the next review by N days using Anki's spec format ("0", "3-7", "1!"), keeping interval and ease, and reads the scheduling back so range specs report where each card landed.

Both validate every card ID via cardsInfo before mutating: AnkiConnect's forgetCards returns null and setDueDate returns true even for IDs that do not exist, so a typo would otherwise look like a successful reset. The shared check lives in card-validation.utils.ts.

Neither action needed a read-only mode change — both were already treated as scheduling operations rather than content writes.